### PR TITLE
deps: bump pytest-cov to >=7.1.0 (supersedes #30)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ isort>=8.0.1
 # Testing
 pytest>=9.0.3
 pytest-django>=4.9
-pytest-cov>=6.0
+pytest-cov>=7.1.0
 factory-boy>=3.3.3
 
 # Type checking


### PR DESCRIPTION
Wrap-up for the weekly dependency sweep. Dependabot #30 conflicted after the other requirements-dev.txt bumps merged; this rolls the same one-line bump in. Dev-only test dependency (coverage plugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)