### PR TITLE
deps: update pytest-django requirement to >=4.12.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ isort>=8.0.1
 
 # Testing
 pytest>=9.1.0
-pytest-django>=4.9
+pytest-django>=4.12.0
 pytest-cov>=7.1.0
 factory-boy>=3.3.3
 


### PR DESCRIPTION
Floor bump, supersedes #42 (conflicted after adjacent pytest/django-stubs lines merged in this sweep). Resolved set verified locally: 175 passed.