### PR TITLE
fix(db): keep SQLite in a writable dir so writes stop failing (ROS-1204)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,13 @@ db.sqlite3-journal
 db.sqlite3-wal
 db.sqlite3-shm
 
+# ...and the whole data/ dir, which is a runtime bind mount. Without this the
+# 404 MB SQLite corpus gets baked into the image (1.27 GB -> most of it the DB)
+# and, worse, a stale snapshot of it sits at /app/data/db.sqlite3 ready to be
+# served silently if the bind mount ever goes missing. (ROS-1204)
+data/
+logs/
+
 # Local Python state
 venv/
 .venv/

--- a/docker-compose.nuc.yml
+++ b/docker-compose.nuc.yml
@@ -40,6 +40,13 @@ services:
       DB_ENGINE: sqlite
       DEBUG: "0"
       ALLOWED_HOSTS: wrestlingdb.org,www.wrestlingdb.org
+      # Keep the DB inside the bind-mounted (app-writable) ./data dir. /app is
+      # root:root 0755 in the image, so SQLite cannot create the `-journal`
+      # file alongside a DB at /app/db.sqlite3 and every write transaction
+      # fails read-only — reads keep working, which is why the healthcheck and
+      # the public pages looked fine while /signup/ 500'd. See SQLITE_PATH in
+      # owdb_django/settings.py.
+      SQLITE_PATH: /app/data/db.sqlite3
     # No public port — only the docker network reaches us. cloudflared
     # service below talks to `http://web:8000` by container name.
     ports: !reset []
@@ -47,9 +54,13 @@ services:
     depends_on: !reset []
     # SQLite + provenance audit DB lives on a host bind mount so it
     # survives rebuilds and can be rsync'd in/out for backups.
+    #
+    # Directory mount only — the old extra `./data/db.sqlite3:/app/db.sqlite3`
+    # single-file mount is gone. It dropped the DB into the unwritable /app
+    # dir, and single-file bind mounts also break if the host file is ever
+    # replaced by inode (rsync without --inplace, restore-from-backup).
     volumes:
       - ./data:/app/data
-      - ./data/db.sqlite3:/app/db.sqlite3
       - static_files:/app/static_collected
     # Override the base command: skip setup_celery_schedule (no celery),
     # run migrations + collectstatic + gunicorn.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,10 +61,20 @@ services:
       - .env
     environment:
       APP_ENV: ${APP_ENV:-production}
+      # NOTE: settings.py picks the engine from DB_ENGINE (default "sqlite") —
+      # USE_POSTGRES / USE_REDIS are read by nothing. So this stack starts
+      # Postgres + Redis and Django then quietly uses SQLite anyway. Set
+      # DB_ENGINE=postgres to actually use the `db` service.
       USE_POSTGRES: "true"
       USE_REDIS: "true"
+      DB_ENGINE: ${DB_ENGINE:-sqlite}
       DB_HOST: db
       DB_PORT: 5432
+      # In SQLite mode the DB has to sit in a directory the app user can write:
+      # /app is root:root 0755 in the image and the app runs as `appuser`, so
+      # SQLite can neither create /app/db.sqlite3 nor its `-journal` and every
+      # DB access dies with "unable to open database file". (ROS-1204)
+      SQLITE_PATH: /app/data/db.sqlite3
       REDIS_URL: redis://redis:6379/0
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
@@ -76,6 +86,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
+      - ./data:/app/data
       - static_files:/app/static_collected
     command: >
       sh -c "
@@ -109,10 +120,20 @@ services:
       - .env
     environment:
       APP_ENV: ${APP_ENV:-production}
+      # NOTE: settings.py picks the engine from DB_ENGINE (default "sqlite") —
+      # USE_POSTGRES / USE_REDIS are read by nothing. So this stack starts
+      # Postgres + Redis and Django then quietly uses SQLite anyway. Set
+      # DB_ENGINE=postgres to actually use the `db` service.
       USE_POSTGRES: "true"
       USE_REDIS: "true"
+      DB_ENGINE: ${DB_ENGINE:-sqlite}
       DB_HOST: db
       DB_PORT: 5432
+      # In SQLite mode the DB has to sit in a directory the app user can write:
+      # /app is root:root 0755 in the image and the app runs as `appuser`, so
+      # SQLite can neither create /app/db.sqlite3 nor its `-journal` and every
+      # DB access dies with "unable to open database file". (ROS-1204)
+      SQLITE_PATH: /app/data/db.sqlite3
       REDIS_URL: redis://redis:6379/0
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
@@ -130,6 +151,7 @@ services:
       --loglevel=info
       --concurrency=2
     volumes:
+      - ./data:/app/data
       - celery_beat_schedule:/app/celerybeat-schedule
     healthcheck:
       test: ["CMD", "celery", "-A", "owdb_django", "inspect", "ping"]

--- a/owdb_django/owdbapp/apps.py
+++ b/owdb_django/owdbapp/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class OwdbappConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "owdb_django.owdbapp"
+
+    def ready(self):
+        # Registers the SQLite-directory-writable deploy check (ROS-1204).
+        from . import checks  # noqa: F401

--- a/owdb_django/owdbapp/checks.py
+++ b/owdb_django/owdbapp/checks.py
@@ -1,0 +1,52 @@
+"""Deploy-time system checks for OWDB.
+
+Registered from OwdbappConfig.ready(), so they run on `manage.py check`,
+`migrate`, `runserver` and the container start command.
+"""
+
+import os
+
+from django.conf import settings
+from django.core.checks import Error, register
+
+SQLITE_DIR_NOT_WRITABLE = "owdbapp.E001"
+
+
+@register()
+def sqlite_directory_is_writable(app_configs, **kwargs):
+    """Fail loudly when the SQLite DB sits in a directory we cannot write.
+
+    SQLite creates a rollback journal (``<db>-journal``) *next to* the database
+    file for every write transaction, and creates the database file itself if it
+    is missing — both need write permission on the containing directory, not just
+    on the .sqlite3 file. Get this wrong and reads keep working while every write
+    fails with "attempt to write a readonly database" (or, when the file does not
+    exist yet, "unable to open database file"). That is a silent, healthcheck-
+    passing outage: it took six weeks to notice /signup/ was 500ing. See ROS-1204.
+    """
+    errors = []
+    for alias, config in settings.DATABASES.items():
+        if "sqlite3" not in config.get("ENGINE", ""):
+            continue
+        name = str(config.get("NAME", ""))
+        # :memory: and other special names have no directory to check.
+        if not name or name.startswith(":"):
+            continue
+        directory = os.path.dirname(os.path.abspath(name))
+        if os.access(directory, os.W_OK):
+            continue
+        errors.append(
+            Error(
+                f"SQLite database {alias!r} is at {name}, but {directory} is not "
+                f"writable by this process (uid {os.getuid()}). Every write will "
+                f"fail even though reads succeed.",
+                hint=(
+                    "Point the database at a writable directory — set the "
+                    "SQLITE_PATH env var (e.g. SQLITE_PATH=/app/data/db.sqlite3, "
+                    "with ./data bind-mounted) rather than leaving it at "
+                    "BASE_DIR/db.sqlite3 inside the read-only image layer."
+                ),
+                id=SQLITE_DIR_NOT_WRITABLE,
+            )
+        )
+    return errors

--- a/owdb_django/settings.py
+++ b/owdb_django/settings.py
@@ -142,11 +142,22 @@ WSGI_APPLICATION = "owdb_django.wsgi.application"
 # corpus straight into the NUC's first deploy harder than it needed to be.
 USE_SQLITE = os.getenv("DB_ENGINE", "sqlite").lower() != "postgres"
 
+# SQLite needs to create a rollback journal (`<db>-journal`) *next to* the
+# database file on every write transaction, so the containing directory has to
+# be writable by the app user — not just the .sqlite3 file itself. In the
+# container image /app is owned by root:root 0755 while the app runs as
+# `appuser`, so a DB at BASE_DIR/db.sqlite3 opens fine for reads and then fails
+# every write with "attempt to write a readonly database" (older SQLite:
+# "unable to open database file"). SQLITE_PATH lets the deploy point the DB at
+# a writable, bind-mounted directory instead. Default keeps the repo-root path
+# for local dev, where the checkout is writable.
+SQLITE_PATH = os.getenv("SQLITE_PATH") or BASE_DIR / "db.sqlite3"
+
 if USE_SQLITE:
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "db.sqlite3",
+            "NAME": SQLITE_PATH,
         }
     }
 else:


### PR DESCRIPTION
## Root cause

SQLite creates the rollback journal (`<db>-journal`) **next to** the database file on every write transaction, and creates the DB file itself when it's missing. Both need write permission on the *containing directory*, not just on the `.sqlite3` file.

In the container image `/app` is `root:root 0755` while the app runs as `appuser`, so a DB at `BASE_DIR/db.sqlite3` opens fine for reads and then fails every write:

| DB file at `/app/db.sqlite3` | error |
|---|---|
| present (bind-mounted) | `OperationalError: attempt to write a readonly database` |
| absent | `OperationalError: unable to open database file` |

Reads keep working and `/health/` keeps returning 2xx/3xx, so this is a **silent** outage.

- On wrestlingdb.org (NUC) it left `POST /signup/` 500ing since the 2026-06-18 deploy — 7 real signup attempts failed, `auth_user` count is 0.
- The `unable to open database file` variant is what's filling the `owdb` Sentry project (ROS-1204 weekly digest, 4 issues / 27 events).

## Changes

- `settings.py` — new `SQLITE_PATH` env override. Default unchanged (`BASE_DIR/db.sqlite3`), which is fine for local dev where the checkout is writable.
- `docker-compose.nuc.yml` — `SQLITE_PATH=/app/data/db.sqlite3`; drop the extra `./data/db.sqlite3:/app/db.sqlite3` single-file bind mount. The directory mount already exposes the same file (verified: same inode), and single-file bind mounts also break when the host file is replaced by inode (rsync without `--inplace`, restore-from-backup).
- `docker-compose.yml` — same `SQLITE_PATH` + `./data` mount for `web` **and** `celery`. Also documents that `settings.py` selects the engine from `DB_ENGINE`; the `USE_POSTGRES` / `USE_REDIS` vars this file sets are read by nothing, so the stack starts Postgres + Redis and Django then quietly uses SQLite. I left the default as sqlite (now `${DB_ENGINE:-sqlite}`) rather than flipping the engine under anyone — that call is Eric's.
- `owdbapp/checks.py` — deploy-time system check `owdbapp.E001` that fails loudly when the SQLite DB's directory isn't writable, so this can't regress silently again.

## Verification

Run against the **live production image** (`wrestlingdb-web:latest`) on the NUC, in throwaway `docker run --rm` containers, using a scratch copy of the 404 MB prod DB — the running site was untouched:

- With the fix: `INSERT` into `auth_user` commits, then deletes cleanly. `DB NAME: /app/data/qscratch.sqlite3` → `INSERT_OK id= 1` → `DELETE_OK`.
- Without the fix, same image: reproduced `attempt to write a readonly database` (file present) and `unable to open database file` (file absent).
- New check: reports `owdbapp.E001` on the broken layout, `no issues` on the fixed one.
- Merged compose config validated with `docker compose config` (the `./data` mounts dedupe correctly across base + nuc override).

## Note on deploying this to the NUC

The NUC's `/home/eric/wrestlingdb` is an rsync'd snapshot, **not** a git checkout, and it's behind `main` (repo-wide ruff reformat, plus unapplied migration `0029_videogame_book_image_fields` and two new `wrestlebot/pipeline` modules). Syncing `main` to prod would auto-apply a schema migration to the live 404 MB DB at container start, so I applied only the equivalent minimal patch on the host and left the wider sync/migration decision to Eric. `deploy.sh` also targets `137.184.7.163:/opt/owdb`, a droplet that no longer answers — it's stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)