### PR TITLE
fix(health): stop the container healthcheck passing on a 301 (ROS-1207)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,11 @@ RUN python manage.py collectstatic --noinput
 # Expose port
 EXPOSE 8000
 
-# Health check
+# Health check — assert an explicit 200. `curl -f` alone treats a 3xx as
+# success, so it passed on the SECURE_SSL_REDIRECT 301 that plain-HTTP
+# localhost gets, never reaching the view. (ROS-1207)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/health/ || exit 1
+    CMD curl -fsS --max-time 5 -o /dev/null -w '%{http_code}' http://localhost:8000/health/ | grep -q '^200$' || exit 1
 
 # Run with Gunicorn
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "2", "--threads", "4", "--worker-class", "gthread", "--access-logfile", "-", "--error-logfile", "-", "owdb_django.wsgi:application"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,16 @@ services:
         gunicorn --bind 0.0.0.0:8000 --workers 2 --threads 4 --worker-class gthread --access-logfile - --error-logfile - owdb_django.wsgi:application
       "
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health/"]
+      # Assert an explicit 200 rather than trusting curl's exit code: `curl -f`
+      # counts any 3xx as success, so the old form passed on the SSL-redirect
+      # 301 without ever reaching the view. SECURE_REDIRECT_EXEMPT now stops
+      # that redirect; this keeps the check honest if it ever comes back.
+      # (ROS-1207)
+      test:
+        - CMD-SHELL
+        - >-
+          curl -fsS --max-time 5 -o /dev/null -w '%{http_code}'
+          http://localhost:8000/health/ | grep -q '^200$$'
       interval: 30s
       timeout: 10s
       retries: 3

--- a/owdb_django/owdbapp/tests/test_security.py
+++ b/owdb_django/owdbapp/tests/test_security.py
@@ -150,3 +150,29 @@ class SessionSecurityTest(TestCase):
         self.client.post(reverse("logout"))
         # Session cookie should be cleared
         self.assertEqual(self.client.cookies["sessionid"].value, "")
+
+
+class HealthCheckRedirectExemptTest(TestCase):
+    """The container healthcheck hits /health/ over plain HTTP on localhost.
+
+    With SECURE_SSL_REDIRECT on and no exemption, SecurityMiddleware returns a
+    301 before the view runs, and `curl -f` counts that as success — so the
+    check reported healthy while the app was broken (ROS-1204/ROS-1207).
+    """
+
+    def setUp(self):
+        self.client = Client()
+
+    @override_settings(SECURE_SSL_REDIRECT=True, SECURE_REDIRECT_EXEMPT=[r"^health/$"])
+    def test_health_is_not_ssl_redirected(self):
+        """/health/ answers over plain HTTP instead of redirecting."""
+        response = self.client.get("/health/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "healthy")
+
+    @override_settings(SECURE_SSL_REDIRECT=True, SECURE_REDIRECT_EXEMPT=[r"^health/$"])
+    def test_other_paths_still_ssl_redirect(self):
+        """The exemption is scoped to /health/ — everything else still 301s."""
+        response = self.client.get(reverse("index"))
+        self.assertEqual(response.status_code, 301)
+        self.assertTrue(response["Location"].startswith("https://"))

--- a/owdb_django/settings.py
+++ b/owdb_django/settings.py
@@ -68,6 +68,15 @@ if not DEBUG:
     CSRF_COOKIE_SAMESITE = "Lax"
     # Redirect HTTP to HTTPS
     SECURE_SSL_REDIRECT = True
+    # …except /health/. The container healthcheck and any other in-network
+    # caller reaches gunicorn over plain HTTP on localhost:8000, where the
+    # redirect fires and hands back a 301 before the view ever runs. `curl -f`
+    # treats 3xx as success, so the check reported healthy for as long as
+    # gunicorn could emit a redirect — including the six weeks the write path
+    # was dead in ROS-1204. Exempting the path makes the endpoint honest for
+    # every internal caller, not just the one curl. (ROS-1207)
+    # Matched by SecurityMiddleware against request.path.lstrip("/").
+    SECURE_REDIRECT_EXEMPT = [r"^health/$"]
 
 # Session security (applies to both dev and prod)
 SESSION_COOKIE_AGE = 86400 * 14  # 14 days


### PR DESCRIPTION
## Problem

The web container healthcheck is `curl -f http://localhost:8000/health/`. Over plain HTTP on localhost, `SECURE_SSL_REDIRECT` returns a **301** before the view runs, and `curl -f` without `--location` treats 3xx as success. From the access log, every 30s:

```
127.0.0.1 - - [25/Jul/2026:18:04:52 +0000] "GET /health/ HTTP/1.1" 301 0 "-" "curl/8.14.1"
```

So the check never reached `health_check()`. It reported `healthy` as long as gunicorn could emit a redirect. Over HTTPS the endpoint is fine (`https://wrestlingdb.org/health/` → 200).

This is a direct contributor to ROS-1204 staying hidden for six weeks — Docker said `Up (healthy)` the entire time the write path was dead. Worth noting the NUC also runs an `autoheal` container that acts on health status, so the vacuous check disarmed that too.

## Change

- `SECURE_REDIRECT_EXEMPT = [r"^health/$"]` — the issue's preferred option, since it makes the endpoint honest for *any* internal caller rather than just the one curl.
- Healthcheck now asserts an explicit `200` instead of trusting curl's exit code, in both `docker-compose.yml` and the image-level `HEALTHCHECK`. Belt and braces: if the redirect ever comes back, the check fails loudly instead of silently passing again.
- Regression tests in `test_security.py` covering both directions (health exempt, everything else still 301s).

## Verification

Built from this tree and run as a throwaway container on the NUC, before touching the live service:

| check | result |
|---|---|
| `GET /health/` over plain HTTP | `200`, body `{"status": "healthy", "database": "connected"}` |
| `GET /` over plain HTTP | `301` — SSL redirect still enforced everywhere else |
| new healthcheck cmd vs `/health/` | exit 0 (pass) |
| new healthcheck cmd vs a 301 | exit non-zero (correctly fails) |
| **old** healthcheck cmd vs a 301 | exit 0 — confirms the bug |
| `manage.py test ...HealthCheckRedirectExemptTest` | 2 tests, OK |

Then deployed to the NUC (`docker compose up -d web`). Live now:

```
127.0.0.1 - - [25/Jul/2026:18:40:52 +0000] "GET /health/ HTTP/1.1" 200 46 "-" "curl/8.14.1"
```

Container reached `healthy` in ~5s via a real 200, `https://wrestlingdb.org/` and `/health/` both 200.

Note: GitHub Actions is billing-disabled on this account, so CI will not run here — the verification above was done by hand. The wider `test_security.py` suite has 10 pre-existing failures unrelated to this change (stale assertions that predate `SECURE_SSL_REDIRECT`); filing that separately rather than widening this PR.

Closes ROS-1207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)