### PR TITLE
fix(health): make /health/ notice a dead write path (ROS-1209)

### DIFF
--- a/owdb_django/owdbapp/checks.py
+++ b/owdb_django/owdbapp/checks.py
@@ -12,6 +12,28 @@ from django.core.checks import Error, register
 SQLITE_DIR_NOT_WRITABLE = "owdbapp.E001"
 
 
+def sqlite_db_directory(config):
+    """Return the directory holding ``config``'s SQLite file, or None.
+
+    None means "no directory to check" — a non-SQLite engine, or a database
+    that does not live on disk at all.
+
+    The in-memory cases are worth spelling out. Django's test runner does not
+    use the plain ``:memory:`` name; it swaps NAME for the shared-cache URI
+    ``file:memorydb_default?mode=memory&cache=shared``. That does not start
+    with ":", so treating it as a path yields the *current working directory*,
+    and the writability check then fails on any run whose cwd happens to be
+    read-only. It fired on the first containerised test run of ROS-1209 and
+    aborted the whole suite with owdbapp.E001 before a single test executed.
+    """
+    if "sqlite3" not in config.get("ENGINE", ""):
+        return None
+    name = str(config.get("NAME", ""))
+    if not name or name.startswith(":") or "mode=memory" in name:
+        return None
+    return os.path.dirname(os.path.abspath(name))
+
+
 @register()
 def sqlite_directory_is_writable(app_configs, **kwargs):
     """Fail loudly when the SQLite DB sits in a directory we cannot write.
@@ -26,13 +48,10 @@ def sqlite_directory_is_writable(app_configs, **kwargs):
     """
     errors = []
     for alias, config in settings.DATABASES.items():
-        if "sqlite3" not in config.get("ENGINE", ""):
+        directory = sqlite_db_directory(config)
+        if directory is None:
             continue
         name = str(config.get("NAME", ""))
-        # :memory: and other special names have no directory to check.
-        if not name or name.startswith(":"):
-            continue
-        directory = os.path.dirname(os.path.abspath(name))
         if os.access(directory, os.W_OK):
             continue
         errors.append(

--- a/owdb_django/owdbapp/tests/test_health.py
+++ b/owdb_django/owdbapp/tests/test_health.py
@@ -1,0 +1,250 @@
+"""Tests for the health endpoints.
+
+ROS-1204 was a write-path outage that lasted six weeks because the health
+endpoint only ever ran `SELECT 1`, which reads straight through it. ROS-1207
+fixed the container healthcheck so it actually reached the view. These tests
+cover the other half: making the view itself notice.
+"""
+
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+from django.db import OperationalError, connection
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+
+from .. import views
+from ..checks import sqlite_db_directory
+
+
+class HealthCheckTest(TestCase):
+    """The cheap liveness probe at /health/ — what Docker hits every 30s."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_healthy(self):
+        response = self.client.get(reverse("health"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["status"], "healthy")
+        # Kept for anything already parsing the old response shape.
+        self.assertEqual(data["database"], "connected")
+        self.assertEqual(data["checks"]["database"], "connected")
+
+    def test_unhealthy_when_sqlite_directory_is_not_writable(self):
+        """The ROS-1204 shape: DB reads fine, DB directory rejects writes."""
+        with mock.patch.object(
+            views,
+            "_check_sqlite_dir_writable",
+            return_value=(False, "/app is not writable by uid 1000"),
+        ):
+            response = self.client.get(reverse("health"))
+        self.assertEqual(response.status_code, 503)
+        data = response.json()
+        self.assertEqual(data["status"], "unhealthy")
+        self.assertIn("not writable", data["error"])
+
+    def test_does_not_write(self):
+        """The liveness probe must stay cheap — no write, no lock.
+
+        If this ever starts writing it belongs on /health/ready/ instead: the
+        container healthcheck runs it every 30s, and anything that can flap
+        under load becomes a restart loop the moment autoheal watches it.
+        """
+        with mock.patch.object(
+            views, "_check_write_transaction", side_effect=AssertionError("wrote")
+        ):
+            response = self.client.get(reverse("health"))
+        self.assertEqual(response.status_code, 200)
+
+
+@unittest.skipIf(os.getuid() == 0, "root bypasses directory permissions")
+class SqliteDirectoryWritableTest(TestCase):
+    """Reproduce ROS-1204 on a throwaway DB and prove each probe's verdict."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "db.sqlite3")
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE t (x integer)")
+        conn.execute("INSERT INTO t VALUES (1)")
+        conn.commit()
+        conn.close()
+
+    def tearDown(self):
+        os.chmod(self.tmpdir, 0o755)
+
+    def _override(self):
+        return override_settings(
+            DATABASES={
+                "default": {
+                    "ENGINE": "django.db.backends.sqlite3",
+                    "NAME": self.db_path,
+                }
+            }
+        )
+
+    def test_select_1_passes_through_the_failure(self):
+        """Why `SELECT 1` was never enough — it succeeds on a dead write path."""
+        os.chmod(self.tmpdir, 0o555)
+        conn = sqlite3.connect(self.db_path, isolation_level=None)
+        try:
+            self.assertEqual(conn.execute("SELECT 1").fetchone()[0], 1)
+            # So does taking the write lock — SQLite only fails once it goes to
+            # create the journal, so a lock-only probe is just as blind.
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute("ROLLBACK")
+            with self.assertRaises(sqlite3.OperationalError):
+                conn.execute("INSERT INTO t VALUES (2)")
+        finally:
+            conn.close()
+
+    def test_directory_check_catches_it(self):
+        os.chmod(self.tmpdir, 0o555)
+        with self._override():
+            ok, detail = views._check_sqlite_dir_writable()
+        self.assertFalse(ok)
+        self.assertIn("not writable", detail)
+
+    def test_directory_check_passes_when_writable(self):
+        with self._override():
+            ok, detail = views._check_sqlite_dir_writable()
+        self.assertTrue(ok)
+        self.assertEqual(detail, "writable")
+
+    def test_directory_check_is_skipped_on_postgres(self):
+        with override_settings(
+            DATABASES={
+                "default": {
+                    "ENGINE": "django.db.backends.postgresql",
+                    "NAME": "owdb",
+                }
+            }
+        ):
+            ok, detail = views._check_sqlite_dir_writable()
+        self.assertTrue(ok)
+        self.assertEqual(detail, "n/a (no on-disk sqlite file)")
+
+
+class SqliteDbDirectoryTest(TestCase):
+    """The shared helper behind both owdbapp.E001 and /health/."""
+
+    def test_in_memory_databases_have_no_directory(self):
+        """Django's test runner uses a URI, not ``:memory:``.
+
+        Treating ``file:memorydb_default?mode=memory&cache=shared`` as a path
+        resolves it against the cwd, so owdbapp.E001 fired and aborted the
+        whole suite the first time the tests ran with a read-only cwd.
+        """
+        for name in (
+            ":memory:",
+            "file:memorydb_default?mode=memory&cache=shared",
+            "",
+        ):
+            with self.subTest(name=name):
+                self.assertIsNone(
+                    sqlite_db_directory({"ENGINE": "django.db.backends.sqlite3", "NAME": name})
+                )
+
+    def test_on_disk_database_returns_its_directory(self):
+        self.assertEqual(
+            sqlite_db_directory(
+                {"ENGINE": "django.db.backends.sqlite3", "NAME": "/app/data/db.sqlite3"}
+            ),
+            "/app/data",
+        )
+
+    def test_non_sqlite_engine_returns_none(self):
+        self.assertIsNone(
+            sqlite_db_directory({"ENGINE": "django.db.backends.postgresql", "NAME": "owdb"})
+        )
+
+
+class HealthReadyTest(TestCase):
+    """The deep readiness probe at /health/ready/ — humans and monitoring."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_ready(self):
+        response = self.client.get(reverse("health_ready"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["status"], "healthy")
+        self.assertEqual(data["checks"]["database"], "connected")
+        self.assertEqual(data["checks"]["database_write"], "ok")
+
+    def test_write_probe_leaves_nothing_behind(self):
+        ok, _ = views._check_write_transaction()
+        self.assertTrue(ok)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = %s",
+                [views._WRITE_PROBE_TABLE],
+            )
+            self.assertEqual(cursor.fetchone()[0], 0)
+
+    def test_write_probe_reports_failure(self):
+        with mock.patch.object(
+            views.connection,
+            "cursor",
+            side_effect=OperationalError("attempt to write a readonly database"),
+        ):
+            ok, detail = views._check_write_transaction()
+        self.assertFalse(ok)
+        self.assertIn("readonly", detail)
+
+    def test_busy_database_is_not_reported_unhealthy(self):
+        """Lock contention means writes work — the opposite of the failure.
+
+        Reporting it unhealthy is the false negative that makes a strict probe
+        dangerous, so it is explicitly downgraded.
+        """
+        with mock.patch.object(
+            views.connection, "cursor", side_effect=OperationalError("database is locked")
+        ):
+            ok, detail = views._check_write_transaction()
+        self.assertTrue(ok)
+        self.assertIn("busy", detail)
+
+    def test_unhealthy_when_write_fails(self):
+        with mock.patch.object(
+            views,
+            "_check_write_transaction",
+            return_value=(False, "attempt to write a readonly database"),
+        ):
+            response = self.client.get(reverse("health_ready"))
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["status"], "unhealthy")
+
+
+class HealthReadyRedirectExemptTest(TestCase):
+    """/health/ready/ is reached over plain HTTP inside the network too.
+
+    Without an exemption SecurityMiddleware 301s it before the view runs and
+    the verdict never reaches the caller — the ROS-1207 failure, one path over.
+    """
+
+    def setUp(self):
+        self.client = Client()
+
+    @override_settings(
+        SECURE_SSL_REDIRECT=True,
+        SECURE_REDIRECT_EXEMPT=[r"^health/$", r"^health/ready/$"],
+    )
+    def test_health_ready_is_not_ssl_redirected(self):
+        response = self.client.get("/health/ready/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "healthy")
+
+    @override_settings(
+        SECURE_SSL_REDIRECT=True,
+        SECURE_REDIRECT_EXEMPT=[r"^health/$", r"^health/ready/$"],
+    )
+    def test_other_paths_still_ssl_redirect(self):
+        response = self.client.get(reverse("index"))
+        self.assertEqual(response.status_code, 301)

--- a/owdb_django/owdbapp/views.py
+++ b/owdb_django/owdbapp/views.py
@@ -1078,19 +1078,147 @@ def account(request):
 # Health Check (for Docker/Load Balancers)
 # =============================================================================
 
+import os
+
 from django.http import JsonResponse
-from django.db import connection
+from django.db import connection, transaction
+
+from .checks import sqlite_db_directory
+
+# Name of the throwaway table the readiness probe creates and rolls back. It
+# never survives the probe — the CREATE is followed by a DROP and the whole
+# transaction is rolled back on top of that.
+_WRITE_PROBE_TABLE = "owdb_health_write_probe"
+
+
+class _ProbeRollback(Exception):
+    """Sentinel raised to unwind the readiness write probe's transaction."""
+
+
+def _check_sqlite_dir_writable():
+    """Cheap stand-in for the ROS-1204 failure mode.
+
+    SQLite writes its rollback journal *next to* the database file, so a write
+    transaction needs the containing directory to be writable — a permission
+    `SELECT 1` never exercises. Under the exact ROS-1204 conditions (DB file
+    present and readable, parent directory root:root 0755, app running as
+    appuser) `SELECT 1` returns cleanly, and so does `BEGIN IMMEDIATE`: SQLite
+    only discovers it cannot write when it goes to create the journal. Both
+    were verified against a reproduction before this check was written.
+
+    ``os.access`` is a real permission check against the running uid — it also
+    reports False for a read-only mount — so this cannot flap the way an actual
+    write can (lock contention, transient ENOSPC). That matters: a probe that
+    ever false-negatives on the Docker healthcheck path turns a live site into
+    a restart loop the moment anything is wired up to act on the status.
+
+    Returns (ok, detail).
+    """
+    directory = sqlite_db_directory(settings.DATABASES["default"])
+    if directory is None:
+        return True, "n/a (no on-disk sqlite file)"
+    if os.access(directory, os.W_OK | os.X_OK):
+        return True, "writable"
+    return False, (
+        f"{directory} is not writable by uid {os.getuid()}; every write will "
+        f"fail while reads keep succeeding (see ROS-1204)"
+    )
+
+
+def _check_write_transaction():
+    """Open a real write transaction against the default DB and roll it back.
+
+    Engine-agnostic, and stricter than the directory check: it also catches a
+    read-only Postgres (hot standby, ``default_transaction_read_only``), a
+    connection opened read-only, and a SQLite DB file that is itself unwritable
+    in a writable directory. Creating a table dirties a page, which is what
+    forces SQLite to open the journal — the precise step ROS-1204 died on.
+
+    Nothing survives: the CREATE is followed by a DROP inside the same atomic
+    block, and the block is then unwound by ``_ProbeRollback`` regardless.
+
+    A busy database is reported as "busy", not unhealthy. Lock contention means
+    somebody else is writing successfully, which is the opposite of the failure
+    this is looking for, and calling it unhealthy would be exactly the kind of
+    false negative that makes a strict probe dangerous.
+
+    Returns (ok, detail).
+    """
+    try:
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute(f"CREATE TABLE {_WRITE_PROBE_TABLE} (id integer)")
+                cursor.execute(f"DROP TABLE {_WRITE_PROBE_TABLE}")
+            raise _ProbeRollback
+    except _ProbeRollback:
+        return True, "ok"
+    except Exception as e:
+        message = str(e).lower()
+        if "locked" in message or "busy" in message or "deadlock" in message:
+            return True, f"busy (another writer holds the lock): {e}"
+        return False, str(e)
 
 
 def health_check(request):
-    """Health check endpoint for Docker and load balancers."""
+    """Liveness probe for Docker and load balancers.
+
+    Deliberately cheap — no write, no lock, no added load — because this is the
+    endpoint the container healthcheck hits every 30s. `SELECT 1` on its own is
+    not enough: it passed straight through all six weeks of ROS-1204, when
+    every write was failing. The SQLite directory check closes that specific
+    hole at the cost of two syscalls. Use /health/ready/ for the deep check.
+    """
+    checks = {}
     try:
-        # Check database connection
         with connection.cursor() as cursor:
             cursor.execute("SELECT 1")
-        return JsonResponse({"status": "healthy", "database": "connected"})
+        checks["database"] = "connected"
     except Exception as e:
-        return JsonResponse({"status": "unhealthy", "error": str(e)}, status=503)
+        return JsonResponse(
+            {"status": "unhealthy", "checks": {"database": str(e)}, "error": str(e)},
+            status=503,
+        )
+
+    ok, detail = _check_sqlite_dir_writable()
+    checks["database_directory"] = detail
+    if not ok:
+        return JsonResponse({"status": "unhealthy", "checks": checks, "error": detail}, status=503)
+
+    # "database": "connected" is kept for anything already parsing this shape.
+    return JsonResponse({"status": "healthy", "database": "connected", "checks": checks})
+
+
+def health_ready(request):
+    """Readiness probe for humans and monitoring — everything /health/ does,
+    plus a real write transaction that is rolled back.
+
+    Kept off the container healthcheck path on purpose. It takes a brief write
+    lock, so running it every 30s against a live SQLite site trades a real
+    (small) risk for information nobody is reading at that frequency.
+    """
+    checks = {}
+    status = 200
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+        checks["database"] = "connected"
+    except Exception as e:
+        checks["database"] = str(e)
+        return JsonResponse({"status": "unhealthy", "checks": checks}, status=503)
+
+    for key, check in (
+        ("database_directory", _check_sqlite_dir_writable),
+        ("database_write", _check_write_transaction),
+    ):
+        ok, detail = check()
+        checks[key] = detail
+        if not ok:
+            status = 503
+
+    return JsonResponse(
+        {"status": "healthy" if status == 200 else "unhealthy", "checks": checks},
+        status=status,
+    )
 
 
 # =============================================================================

--- a/owdb_django/settings.py
+++ b/owdb_django/settings.py
@@ -76,7 +76,10 @@ if not DEBUG:
     # was dead in ROS-1204. Exempting the path makes the endpoint honest for
     # every internal caller, not just the one curl. (ROS-1207)
     # Matched by SecurityMiddleware against request.path.lstrip("/").
-    SECURE_REDIRECT_EXEMPT = [r"^health/$"]
+    # /health/ready/ is exempt for the same reason — it is reached over plain
+    # HTTP from inside the network, and a 301 would hide its verdict from the
+    # humans and monitoring it exists for. (ROS-1209)
+    SECURE_REDIRECT_EXEMPT = [r"^health/$", r"^health/ready/$"]
 
 # Session security (applies to both dev and prod)
 SESSION_COOKIE_AGE = 86400 * 14  # 14 days

--- a/owdb_django/urls.py
+++ b/owdb_django/urls.py
@@ -77,6 +77,9 @@ urlpatterns = [
     path("resend-verification/", views.resend_verification, name="resend_verification"),
     # Account
     path("account/", views.account, name="account"),
-    # Health check for Docker/load balancers
+    # Health check for Docker/load balancers — cheap, hit every 30s.
     path("health/", views.health_check, name="health"),
+    # Deeper readiness check for humans and monitoring. Kept off the container
+    # healthcheck path because it opens a real write transaction. (ROS-1209)
+    path("health/ready/", views.health_ready, name="health_ready"),
 ]


### PR DESCRIPTION
Closes ROS-1209. Follows ROS-1207 (#84) and ROS-1204 (#82).

## The problem, demonstrated not asserted

`health_check()` ran a single `SELECT 1`. ROS-1204 was a **write**-path failure, so reads kept working and the endpoint reported healthy through all six weeks of it.

I reproduced the ROS-1204 state against the actual `wrestlingdb-web` production image — DB directory made unwritable, confirmed genuinely broken by a real `User.objects.create_user()` raising `attempt to write a readonly database`:

```
--- CURRENT PROD CODE, DB dir unwritable (the ROS-1204 state) ---
{"status": "healthy", "database": "connected"}
HTTP 200
--- container healthcheck command verdict ---
healthcheck says: HEALTHY
```

ROS-1207 removed one layer of false reassurance. This is the other.

## What changed

Split the endpoint, per the issue's recommendation, so the strict check stays off the restart path.

**`/health/` — liveness.** What Docker hits every 30s. Adds `os.access(dir, W_OK|X_OK)` on the SQLite directory. Two syscalls, no write, no lock, no added load.

**`/health/ready/` — readiness.** For humans and monitoring. Everything above plus a real write transaction, rolled back (`CREATE`+`DROP` inside `transaction.atomic()`, unwound by a sentinel). Engine-agnostic, so it also covers a read-only Postgres and a DB file that is itself unwritable in a writable directory. Exempted from `SECURE_SSL_REDIRECT` for the same reason `/health/` was.

Same conditions, after:

```
--- UNWRITABLE: /health/ ---
{"status": "unhealthy", "checks": {"database": "connected", "database_directory":
 "/scratch is not writable by uid 1000; every write will fail while reads keep
  succeeding (see ROS-1204)"}, ...}
HTTP 503

--- UNWRITABLE: /health/ready/ ---
{"status": "unhealthy", "checks": {..., "database_write": "attempt to write a readonly database"}}
HTTP 503
```

Healthy state stays `200` on both, and `/health/` keeps its `"database": "connected"` key for anything already parsing that shape.

## Two things worth knowing

**A lock-only probe would have been no better than `SELECT 1`.** I tested `BEGIN IMMEDIATE` before writing any of this — it also passes cleanly through the ROS-1204 failure, because SQLite only discovers it cannot write when it goes to create the journal. There is a test pinning that so nobody "optimises" the probe into uselessness later.

**False negatives are treated as the real danger.** `os.access` is a permission check against the running uid rather than an operation that can flap under load or transient `ENOSPC`. And a busy database is reported `"busy"`, not unhealthy — lock contention means somebody else is writing successfully, which is the opposite of the failure being looked for.

## Latent bug fixed on the way

Django's test runner swaps `NAME` for `file:memorydb_default?mode=memory&cache=shared`. That does not start with `":"`, so the ROS-1204 guard resolved it against the **cwd** and raised `owdbapp.E001`, aborting the whole suite before a single test ran, on any host whose cwd is read-only. It fired on the first containerised run of this branch. The directory logic is now one shared helper (`checks.sqlite_db_directory`) used by both the system check and the probe, so they cannot drift.

## Testing

79/79 in `owdb_django.owdbapp.tests` pass inside the `wrestlingdb-web` image (17 new, including a real chmod-based ROS-1204 reproduction). `ruff check` and `ruff format --check` clean. GitHub Actions is still billing-blocked on this account, so all of the above was run locally against the production image rather than in CI.

## Not deployed — see the issue thread

The NUC production tree is **not** running this repo's `main`; ROS-1204/1207 were hand-patched into the older snapshot and `checks.py` is not deployed there at all. Shipping this to prod is a sync-prod-to-main operation, which is what #83 (ROS-1206) exists to gate. Flagged for Eric rather than pushed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)