### PR TITLE
test: make the suite carry signal under production settings (ROS-1210)

### DIFF
--- a/owdb_django/owdbapp/tests/proxied_client.py
+++ b/owdb_django/owdbapp/tests/proxied_client.py
@@ -1,0 +1,44 @@
+"""A test client whose requests arrive the way production traffic does.
+
+Production sets ``SECURE_SSL_REDIRECT = True`` (settings.py, the ``if not DEBUG``
+block), so SecurityMiddleware answers any request that does not look like HTTPS
+with a 301 before the view runs. Real traffic never sees that redirect: it comes
+through the Cloudflare tunnel, which sets ``X-Forwarded-Proto``, and
+``SECURE_PROXY_SSL_HEADER`` tells Django to trust it.
+
+The Django test client speaks plain HTTP, so under ``APP_ENV=production`` every
+request 301s and each assertion silently checks the redirect instead of the thing
+it names. That is how 34 tests across test_security.py and test_views.py came to
+be red without anyone noticing a real regression (ROS-1210).
+
+Two details that are easy to get wrong:
+
+* Passing ``secure=True`` per request is not enough. ``assertRedirects`` re-fetches
+  the redirect target with ``secure`` derived from the Location scheme, and our
+  Locations are relative, so the follow-up request 301s anyway. Setting the headers
+  on the client covers the request under test *and* every request the assertion
+  helpers make on its behalf.
+* ``X-Forwarded-Port`` is not optional. Settings enables ``USE_X_FORWARDED_PORT``,
+  so without it ``request.get_host()`` reports ``testserver:80`` on a request Django
+  considers secure. That breaks host-matching checks — CSRF Referer/Origin
+  validation and the login view's open-redirect guard — in a way no real request
+  ever would.
+
+Tests that deliberately exercise the unproxied, plain-HTTP path (the container
+healthcheck reaching /health/, or asserting that non-exempt paths still redirect)
+should keep using a bare ``Client()``.
+"""
+
+from django.test import Client
+
+# What the reverse proxy puts in front of every real production request.
+PROXIED_HTTPS = {"X-Forwarded-Proto": "https", "X-Forwarded-Port": "443"}
+
+
+def proxied_client(*, headers=None, **kwargs):
+    """Return a test ``Client`` that looks like it came through the production proxy.
+
+    Extra ``headers`` are merged on top of the proxy headers; any other keyword
+    argument is passed straight through to ``Client`` (e.g. ``enforce_csrf_checks``).
+    """
+    return Client(headers={**PROXIED_HTTPS, **(headers or {})}, **kwargs)

--- a/owdb_django/owdbapp/tests/test_security.py
+++ b/owdb_django/owdbapp/tests/test_security.py
@@ -1,36 +1,66 @@
 """
 Security tests for OWDB.
+
+These use `proxied_client()` rather than a bare `Client()`. Under
+APP_ENV=production a plain-HTTP test request is 301'd by SecurityMiddleware before
+any view runs, so every assertion below would check the redirect instead of the
+thing it names — see proxied_client.py for the full explanation (ROS-1210).
 """
 
 from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 from django.contrib.auth.models import User
 
+from .proxied_client import proxied_client
+
 
 class SecurityHeadersTest(TestCase):
     """Tests for security headers."""
 
     def setUp(self):
-        self.client = Client()
+        self.client = proxied_client()
 
-    @override_settings(DEBUG=False)
     def test_x_frame_options(self):
-        """Test X-Frame-Options header is set."""
+        """Test X-Frame-Options header is set.
+
+        Not wrapped in override_settings(DEBUG=False): the production security
+        block runs at settings-import time, so flipping DEBUG here changes
+        nothing. DENY holds either way — production sets it explicitly and it is
+        also Django's default.
+        """
         response = self.client.get(reverse("index"))
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get("X-Frame-Options"), "DENY")
 
     def test_content_type_options(self):
         """Test X-Content-Type-Options header."""
         response = self.client.get(reverse("index"))
-        # This should be set by Django's SecurityMiddleware
-        self.assertIn(response.get("X-Content-Type-Options", ""), ["nosniff", None])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get("X-Content-Type-Options"), "nosniff")
+
+    @override_settings(SECURE_SSL_REDIRECT=True)
+    def test_proxied_https_is_not_redirected(self):
+        """A proxied HTTPS request reaches the view instead of being redirected.
+
+        This is the setting the rest of the file leans on. If SECURE_PROXY_SSL_HEADER
+        is ever dropped, this test names the cause — otherwise every other test here
+        fails with an unexplained 301, and production redirect-loops.
+        """
+        response = self.client.get(reverse("index"))
+        self.assertEqual(response.status_code, 200)
 
 
 class CSRFProtectionTest(TestCase):
     """Tests for CSRF protection."""
 
     def setUp(self):
-        self.client = Client(enforce_csrf_checks=True)
+        # Referer is supplied because Django applies strict Referer checking to
+        # HTTPS requests. Without a valid one the 403s below prove only that the
+        # Referer was absent, and would still pass with token checking disabled.
+        # With it, the rejection is "CSRF cookie not set" — the real subject.
+        self.client = proxied_client(
+            enforce_csrf_checks=True, headers={"Referer": "https://testserver/"}
+        )
         self.user = User.objects.create_user(
             username="csrfuser", email="csrf@example.com", password="testpassword123"
         )
@@ -45,7 +75,7 @@ class CSRFProtectionTest(TestCase):
     def test_logout_requires_csrf(self):
         """Test that logout POST requires CSRF token."""
         # Login first (without CSRF checks)
-        client = Client()
+        client = proxied_client()
         client.login(username="csrfuser", password="testpassword123")
 
         # Now try to logout with CSRF enforcement
@@ -57,7 +87,7 @@ class OpenRedirectTest(TestCase):
     """Tests for open redirect prevention."""
 
     def setUp(self):
-        self.client = Client()
+        self.client = proxied_client()
         self.user = User.objects.create_user(
             username="redirectuser", email="redirect@example.com", password="testpassword123"
         )
@@ -85,7 +115,7 @@ class InputValidationTest(TestCase):
     """Tests for input validation."""
 
     def setUp(self):
-        self.client = Client()
+        self.client = proxied_client()
 
     def test_search_handles_special_characters(self):
         """Test that search handles special characters safely."""
@@ -134,7 +164,7 @@ class SessionSecurityTest(TestCase):
     """Tests for session security."""
 
     def setUp(self):
-        self.client = Client()
+        self.client = proxied_client()
         self.user = User.objects.create_user(
             username="sessionuser", email="session@example.com", password="testpassword123"
         )
@@ -147,6 +177,7 @@ class SessionSecurityTest(TestCase):
     def test_session_destroyed_on_logout(self):
         """Test that session is destroyed on logout."""
         self.client.login(username="sessionuser", password="testpassword123")
+        self.assertNotEqual(self.client.cookies["sessionid"].value, "")
         self.client.post(reverse("logout"))
         # Session cookie should be cleared
         self.assertEqual(self.client.cookies["sessionid"].value, "")
@@ -158,6 +189,9 @@ class HealthCheckRedirectExemptTest(TestCase):
     With SECURE_SSL_REDIRECT on and no exemption, SecurityMiddleware returns a
     301 before the view runs, and `curl -f` counts that as success — so the
     check reported healthy while the app was broken (ROS-1204/ROS-1207).
+
+    These use a plain client on purpose: the point is what an unproxied,
+    plain-HTTP caller gets.
     """
 
     def setUp(self):

--- a/owdb_django/owdbapp/tests/test_views.py
+++ b/owdb_django/owdbapp/tests/test_views.py
@@ -1,20 +1,26 @@
 """
 Tests for OWDB views.
+
+These use `proxied_client()` rather than a bare `Client()`. Under
+APP_ENV=production a plain-HTTP test request is 301'd by SecurityMiddleware before
+any view runs, so every assertion below would check the redirect instead of the
+view — see proxied_client.py for the full explanation (ROS-1210).
 """
 
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
 from django.utils import timezone
 
 from ..models import Wrestler, Promotion, Event, Venue, UserProfile
+from .proxied_client import proxied_client
 
 
 class PublicViewsTest(TestCase):
     """Tests for public-facing views."""
 
     def setUp(self):
-        self.client = Client()
+        self.client = proxied_client()
         # Create some test data
         self.wrestler = Wrestler.objects.create(name="Test Wrestler", hometown="Test City")
         self.promotion = Promotion.objects.create(name="Test Promotion", abbreviation="TP")
@@ -86,7 +92,7 @@ class SearchViewsTest(TestCase):
     """Tests for search functionality."""
 
     def setUp(self):
-        self.client = Client()
+        self.client = proxied_client()
         Wrestler.objects.create(name="John Cena", hometown="West Newbury")
         Wrestler.objects.create(name="CM Punk", hometown="Chicago")
         Wrestler.objects.create(name="Daniel Bryan", hometown="Aberdeen")
@@ -124,7 +130,7 @@ class AuthenticationViewsTest(TestCase):
     """Tests for authentication views."""
 
     def setUp(self):
-        self.client = Client()
+        self.client = proxied_client()
         self.user = User.objects.create_user(
             username="testuser", email="test@example.com", password="testpassword123"
         )
@@ -179,7 +185,7 @@ class RateLimitingTest(TestCase):
     """Tests for rate limiting on auth views."""
 
     def setUp(self):
-        self.client = Client()
+        self.client = proxied_client()
 
     def test_signup_rate_limiting(self):
         """Test that signup is rate limited when the counter is at the limit."""
@@ -217,7 +223,7 @@ class AccountViewsTest(TestCase):
     """Tests for account management views."""
 
     def setUp(self):
-        self.client = Client()
+        self.client = proxied_client()
         self.user = User.objects.create_user(
             username="testuser", email="test@example.com", password="testpassword123"
         )


### PR DESCRIPTION
Fixes ROS-1210.

## What was wrong

`python manage.py test` inside the production image on the NUC: **79 tests, 34 failures** — the 10 in `test_security.py` the issue reported, plus 24 more in `test_views.py`. Every single one was `301 != <expected>`, one shared cause, and not one was a real regression.

Production sets `SECURE_SSL_REDIRECT = True`. The Django test client speaks plain HTTP, so `SecurityMiddleware` answered every request with a 301 before the view ran — each assertion was silently checking the redirect instead of the thing it named. Real traffic never sees that redirect: it arrives through the Cloudflare tunnel, which sets `X-Forwarded-Proto`, and `SECURE_PROXY_SSL_HEADER` tells Django to trust it.

The issue's second hypothesis — that `test_session_destroyed_on_logout` failed because "Django rotates rather than blanks" the cookie — is **not** what was happening. On an HTTPS request the cookie is blanked exactly as asserted (`max-age=0`, value `""`). It was a redirect victim like the other 33.

## The fix

New `tests/proxied_client.py`: a client carrying the headers the proxy puts on every real request, used wherever a test means "a normal production request". Two subtleties are documented there because both are easy to get wrong:

- **`secure=True` per request is not enough.** `assertRedirects` re-fetches the target with `secure` derived from the Location scheme, and our Locations are relative — so the follow-up request 301s anyway. Verified: `secure=True` still fails `test_login_allows_internal_redirect`.
- **`X-Forwarded-Port` is required.** `USE_X_FORWARDED_PORT` is on, so without it `request.get_host()` reports `testserver:80` on a request Django considers secure, and every host-matching check (CSRF Referer/Origin, the login view's open-redirect guard) fails in a way no real request would.

Assertions sharpened where the 301 had been hiding vacuity:

| Test | Was | Now |
|---|---|---|
| `test_x_frame_options` | `@override_settings(DEBUG=False)` — a no-op, the production block runs at settings-import time | decorator dropped, real header asserted |
| `test_content_type_options` | accepted `None`, so a missing header passed | asserts `nosniff` exactly |
| CSRF tests | 403 came from a *missing Referer*; would still pass with token checking off | valid Referer supplied — rejection is now `CSRF cookie not set` |
| `test_session_destroyed_on_logout` | `""` could pass by never having been set | asserts non-empty before logout |
| — | proxy trust was implicit | new `test_proxied_https_is_not_redirected` pins it, so dropping `SECURE_PROXY_SSL_HEADER` names its own cause instead of scattering unexplained 301s |

**No production code changed.** Only files under `owdb_django/owdbapp/tests/`.

## Verification

All runs inside the production image (`wrestlingdb-web`) on the NUC, against a scratch copy of the tree — the live container was not touched.

| | `APP_ENV=test` (CI) | `APP_ENV=production` (NUC) |
|---|---|---|
| before | 79 tests, **OK** | 79 tests, **34 failures** |
| after | 80 tests, **OK** | 80 tests, **OK** |

`ruff check .` and `ruff format --check` clean repo-wide (what ci.yml runs).

Every assertion confirmed **live**, not just passing, by mutating the code and watching it go red:

- `X_FRAME_OPTIONS = "SAMEORIGIN"` + `SECURE_CONTENT_TYPE_NOSNIFF = False` → exactly the 2 header tests fail, nothing else
- `SECURE_PROXY_SSL_HEADER = None` → 12 fail, `test_proxied_https_is_not_redirected` among them
- removed the login view's `url_has_allowed_host_and_scheme` guard → `test_login_prevents_open_redirect` errors trying to follow to `evil.com`

That last one is worth flagging: the open-redirect guard had **never** been exercised under production settings. The request 301'd short of the view, so the test passed judgement on a redirect. It is real coverage now.

## The CI gap is not what the issue assumed

Actions being billing-disabled is **not** why this went unnoticed. `ci.yml` runs the suite with `APP_ENV: test`, and `DEBUG = APP_ENV != "production"` — so CI skips the entire `if not DEBUG` production security block. The pre-fix suite is green under `APP_ENV=test` (table above). **A fully working CI would still have missed all 34.**

The real gap is that CI has only ever tested a security configuration production does not run. Filed separately.