### PR TITLE
docs: fix the test label that raised ModuleNotFoundError (ROS-1212)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,16 @@
 # OWDB — Claude Code Instructions
 
 ## Tech stack
-- Django 4.x with Celery for background tasks
-- PostgreSQL (production) / SQLite (dev)
+- Django 5.2 (`requirements.txt` pins `>=5.2,<5.3`) with Celery for background tasks
+- SQLite in production (`/app/data/db.sqlite3` on the NUC) and in dev; PostgreSQL only in CI
 - Sentry error monitoring via sentry-sdk[django]
 
 ## Auto-fix guidelines
-- **Test command:** `python manage.py test owdbapp.tests --verbosity=0`
+- **Test command:** `python manage.py test owdb_django.owdbapp.tests --verbosity=0`
+  The app is installed as `owdb_django.owdbapp`, so a bare `owdbapp.tests` label
+  fails with `ModuleNotFoundError: No module named 'owdbapp'` instead of running
+  anything. CI (`.github/workflows/ci.yml`) runs the whole suite via
+  `python manage.py test`.
 - Only modify files directly named in the stack trace
 - Do not create or modify Django migrations — post a comment on the issue instead
 - Do not modify `models.py` without a migration — post a comment
@@ -18,6 +22,7 @@
 - `owdb_django/owdbapp/models.py` — ORM models (requires migration for schema changes)
 - `owdb_django/owdbapp/scrapers/` — Cagematch, TMDB, Wikipedia, etc.
 - `owdb_django/owdbapp/tasks.py` — Celery background tasks
-- `owdb_django/owdbapp/wrestlebot/` — AI enrichment logic
+- `owdb_django/wrestlebot/` — AI enrichment logic (a sibling app, NOT under `owdbapp/`;
+  the legacy in-app `owdbapp.wrestlebot` module was removed)
 - `owdb_django/settings.py` — Django settings (never hardcode secrets)
 - `owdb_django/owdbapp/tests/` — test suite


### PR DESCRIPTION
Sentry digest `OWDB-9` reported `ModuleNotFoundError: No module named 'owdbapp'`.

`CLAUDE.md` documented the test command as `python manage.py test owdbapp.tests --verbosity=0`, but the app is installed as `owdb_django.owdbapp`, so the bare label never resolves. Reproduced in the production container (`wrestlingdb-web-1`):

```
importlib.import_module("owdbapp.tests")             -> ModuleNotFoundError: No module named 'owdbapp'
importlib.import_module("owdb_django.owdbapp.tests") -> OK

DiscoverRunner.build_suite(["owdbapp.tests"])             -> 1 test
    unittest.loader._FailedTest.owdbapp
    ModuleNotFoundError: No module named 'owdbapp'
DiscoverRunner.build_suite(["owdb_django.owdbapp.tests"]) -> 60 tests
```

unittest wraps the import failure in a placeholder test rather than failing loudly, so the documented command quietly collected **one failing placeholder instead of the 60 real tests**. `.github/workflows/ai-fix.yml` instructs the auto-fix agent to read the test command out of `CLAUDE.md` and run it, so every auto-fix run was verifying nothing.

Two other stale facts in the same file, checked against the running container:

- "Django 4.x" → Django 5.2 (`requirements.txt` pins `>=5.2,<5.3`; container reports `5.2.16`)
- `owdb_django/owdbapp/wrestlebot/` does not exist — the app is a sibling at `owdb_django/wrestlebot/`
- production `DATABASES["default"]["ENGINE"]` is `sqlite3` at `/app/data/db.sqlite3`, not PostgreSQL; Postgres is CI-only

Every remaining path in the file map was verified to exist.

Docs-only; no runtime code touched.

**Note on the other alert in the same digest:** `AttributeError: 'VideoGame' object has no attribute 'title'` is *not* fixed here. `VideoGame` has `name`, never `title`, and no `.title` read on a `VideoGame` exists anywhere in `main`, in the deployed NUC snapshot, on any branch, or in any historical revision of `views.py`. Tracking separately — it needs the Sentry stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)