### PR TITLE
fix(sentry): only report from production unless a DSN is set (ROS-1212)

### DIFF
--- a/SENTRY.md
+++ b/SENTRY.md
@@ -3,9 +3,30 @@
 Project: `rosenberg-digital/owdb` · platform `python-django`
 
 Initialised at the end of `owdb_django/settings.py` so Django config is
-loaded first. DSN is hardcoded but can be overridden by `SENTRY_DSN` env
-var. The Django integration captures unhandled exceptions in views and
+loaded first. The Django integration captures unhandled exceptions in views and
 celery task failures (if `sentry-sdk[django]` exposes the Celery integration
 when celery is also installed).
+
+## Which environments report
+
+`resolve_sentry_dsn()` in `owdb_django/settings.py` decides this:
+
+| `APP_ENV`    | `SENTRY_DSN` env var | Reports?                      |
+| ------------ | -------------------- | ----------------------------- |
+| `production` | unset                | yes — built-in production DSN |
+| anything     | set to a DSN         | yes — that DSN                |
+| anything     | set but empty        | no (kill switch)              |
+| not `production` | unset            | **no**                        |
+
+The built-in DSN used to be the fallback for *every* environment, so any
+checkout — a laptop, a bare `docker compose up`, a CI runner — reported into
+the production project tagged `environment=development`. That produced three
+digest alerts nobody could attribute to a host (ROS-1204, ROS-1206, ROS-1212).
+Non-production runtimes now have to opt in explicitly.
+
+If you *want* a dev box reporting, set `SENTRY_DSN` yourself — ideally to a
+separate Sentry project, so dev noise never lands in the production alert feed.
+
+Covered by `owdb_django/owdbapp/tests/test_sentry_dsn.py`.
 
 `pip install -r requirements.txt` will pull in `sentry-sdk[django]>=2.18`.

--- a/owdb_django/owdbapp/tests/test_sentry_dsn.py
+++ b/owdb_django/owdbapp/tests/test_sentry_dsn.py
@@ -1,0 +1,67 @@
+"""Tests for which environments are allowed to report into Sentry.
+
+ROS-1204, ROS-1206 and ROS-1212 were all `owdb` digest alerts that could not be
+attributed to a host. The cause was the same each time: the production DSN was
+the fallback value for `os.getenv("SENTRY_DSN")`, so any checkout anywhere —
+a laptop, a bare `docker compose up`, a CI runner — reported into the
+production project tagged `environment=development`.
+
+ROS-1212 is the case that made it worth a test. The digest carried
+`AttributeError: 'VideoGame' object has no attribute 'title'`, which does not
+correspond to any code in `main`, in the deployed snapshot, on any branch, or
+in any historical revision — and the production host had Sentry inactive. The
+alert was real; the reporter was not production.
+
+These tests pin the rule: production reports implicitly, everything else has
+to opt in.
+"""
+
+from django.test import SimpleTestCase
+
+from ...settings import PRODUCTION_SENTRY_DSN, resolve_sentry_dsn
+
+
+class ResolveSentryDsnTest(SimpleTestCase):
+    """`SENTRY_DSN` unset means 'production only'."""
+
+    def test_production_gets_the_builtin_dsn(self):
+        self.assertEqual(
+            resolve_sentry_dsn("production", None),
+            PRODUCTION_SENTRY_DSN,
+        )
+
+    def test_development_reports_nowhere(self):
+        """The ROS-1212 shape: a dev checkout must not page production."""
+        self.assertIsNone(resolve_sentry_dsn("development", None))
+
+    def test_unrecognised_environments_report_nowhere(self):
+        for app_env in ("", "test", "staging", "ci", "local"):
+            with self.subTest(app_env=app_env):
+                self.assertIsNone(resolve_sentry_dsn(app_env, None))
+
+
+class ExplicitSentryDsnTest(SimpleTestCase):
+    """An explicitly set `SENTRY_DSN` is authoritative in every environment."""
+
+    def test_explicit_dsn_wins_in_development(self):
+        self.assertEqual(
+            resolve_sentry_dsn("development", "https://k@example.ingest.sentry.io/42"),
+            "https://k@example.ingest.sentry.io/42",
+        )
+
+    def test_explicit_dsn_overrides_the_builtin_in_production(self):
+        self.assertEqual(
+            resolve_sentry_dsn("production", "https://k@example.ingest.sentry.io/42"),
+            "https://k@example.ingest.sentry.io/42",
+        )
+
+    def test_explicit_empty_dsn_turns_reporting_off_in_production(self):
+        """`SENTRY_DSN=""` is the documented kill switch — it must beat the default."""
+        self.assertIsNone(resolve_sentry_dsn("production", ""))
+        self.assertIsNone(resolve_sentry_dsn("production", "   "))
+
+    def test_surrounding_whitespace_is_stripped(self):
+        self.assertEqual(
+            resolve_sentry_dsn("development", "  https://k@example.ingest.sentry.io/42\n"),
+            "https://k@example.ingest.sentry.io/42",
+        )

--- a/owdb_django/settings.py
+++ b/owdb_django/settings.py
@@ -680,22 +680,51 @@ WRESTLEBOT = {
 # =============================================================================
 # SENTRY — error + performance monitoring
 # =============================================================================
-try:
-    import sentry_sdk
-    from sentry_sdk.integrations.django import DjangoIntegration
+# This is the production project's DSN. It is deliberately NOT a blanket
+# default for every environment.
+#
+# ROS-1204, ROS-1206 and ROS-1212 were all digest alerts nobody could trace to
+# a host, because the DSN used to be the fallback for `os.getenv("SENTRY_DSN")`.
+# That meant *any* checkout picked it up — a laptop, a bare `docker compose
+# up`, a CI runner — and reported into the production `owdb` project tagged
+# `environment=development`. Chasing ROS-1212 cost a full pass over every
+# `.title` read in the repo before it turned out prod wasn't the reporter.
+#
+# Production still gets it implicitly. Everywhere else has to opt in by setting
+# SENTRY_DSN explicitly.
+PRODUCTION_SENTRY_DSN = "https://3527ae5df926c7d32962395ce6dbb143@o4507525754060800.ingest.us.sentry.io/4511429590056960"
 
-    sentry_sdk.init(
-        dsn=os.getenv(
-            "SENTRY_DSN",
-            "https://3527ae5df926c7d32962395ce6dbb143@o4507525754060800.ingest.us.sentry.io/4511429590056960",
-        ),
-        environment=APP_ENV,
-        integrations=[DjangoIntegration()],
-        traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.2")),
-        profiles_sample_rate=float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.2")),
-        send_default_pii=False,
-        release=os.getenv("SENTRY_RELEASE"),
-    )
-except ImportError:
-    # sentry-sdk not installed — silently skip
-    pass
+
+def resolve_sentry_dsn(app_env, explicit_dsn):
+    """
+    Decide which DSN Sentry should use, or None to stay uninitialised.
+
+    An explicitly set SENTRY_DSN always wins, including when it is empty —
+    `SENTRY_DSN=""` is the documented way to turn reporting off in production.
+    """
+    if explicit_dsn is not None:
+        return explicit_dsn.strip() or None
+    if app_env == "production":
+        return PRODUCTION_SENTRY_DSN
+    return None
+
+
+SENTRY_DSN = resolve_sentry_dsn(APP_ENV, os.getenv("SENTRY_DSN"))
+
+if SENTRY_DSN:
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.django import DjangoIntegration
+
+        sentry_sdk.init(
+            dsn=SENTRY_DSN,
+            environment=APP_ENV,
+            integrations=[DjangoIntegration()],
+            traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.2")),
+            profiles_sample_rate=float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.2")),
+            send_default_pii=False,
+            release=os.getenv("SENTRY_RELEASE"),
+        )
+    except ImportError:
+        # sentry-sdk not installed — silently skip
+        pass


### PR DESCRIPTION
## Why

The production DSN was the fallback value for `os.getenv("SENTRY_DSN")`, so **any** checkout that imported `settings.py` reported into the production `owdb` project — a laptop, a bare `docker compose up`, a CI runner — tagged `environment=development`.

That is why three digest alerts in a row could not be attributed to a host: ROS-1204, ROS-1206, and now ROS-1212.

ROS-1212 is the clearest case. The digest carried:

```
AttributeError: 'VideoGame' object has no attribute 'title'
```

This matches no code anywhere:

- An AST sweep of **all 44 `.title` attribute reads** in the repo found none that can receive a `VideoGame` — the model has `name`, never `title`. Every hit is on `Book`/`Special`/`ThemeSong`/`PodcastEpisode`/`Match.title` (FK), a `*Fields` dataclass, a search-hit dataclass, or a `str.title` method reference.
- No such read exists in the deployed NUC snapshot, on any branch, or in any historical revision of `views.py`.
- The production container reported `sentry_sdk.get_client().is_active() == False`.
- The NUC is the **only** OWDB checkout on the fleet, so the reporter was off-fleet.

The alert was real. Production was not the source. Six weeks of drift plus a promiscuous DSN meant the only way to tell was to read every line by hand.

## What changed

`resolve_sentry_dsn()` makes the rule explicit and testable:

| `APP_ENV` | `SENTRY_DSN` | Reports? |
| --- | --- | --- |
| `production` | unset | yes — built-in production DSN |
| anything | set to a DSN | yes — that DSN |
| anything | set but empty | no (kill switch, beats the default) |
| not `production` | unset | **no** |

## Verification

Run in a throwaway container against this branch, isolated from prod (separate copy of the code, in-memory test DB, prod container untouched):

```
APP_ENV=production  , no SENTRY_DSN  -> resolved DSN: <built-in>  client active: True
APP_ENV=development , no SENTRY_DSN  -> resolved DSN: None        client active: False
APP_ENV=test        , no SENTRY_DSN  -> resolved DSN: None        client active: False
APP_ENV=development , SENTRY_DSN set -> client active: True
```

**Production error reporting is unchanged.** 201 tests pass (`owdbapp` + `wrestlebot`), including 7 new ones in `owdb_django/owdbapp/tests/test_sentry_dsn.py`. `ruff format --check` and `ruff check` both clean.

CI cannot run (Actions billing disabled on the account), so the above was verified locally.

## Not fixed here

The underlying `VideoGame`/`title` defect, wherever it lives, is untouched — it is not in this repo's code. If it recurs after this merge it will be attributable, because only production can report without an explicit opt-in.

Companion PR: #87 (fixes the `ModuleNotFoundError: No module named 'owdbapp'` from the same digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)