### PR TITLE
test: gate the production security config from a test-env suite (ROS-1214)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,21 @@ jobs:
       - run: ruff format --check .
 
   test:
-    name: Test
+    # Run the suite the way production is configured as well as the way CI always
+    # has. `DEBUG = APP_ENV != "production"` gates the entire security block in
+    # settings.py, so with APP_ENV=test alone this job has never executed HSTS,
+    # the secure-cookie flags, the SSL redirect or the /health/ exemptions — a
+    # fully green run missed all 34 failures found in ROS-1210 (ROS-1214).
+    #
+    # This matrix is the belt; the braces are owdbapp/tests/test_production_settings.py,
+    # which asserts the same config from inside the suite and so keeps working
+    # while Actions is billing-disabled and nothing here runs at all.
+    name: Test (APP_ENV=${{ matrix.app_env }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app_env: [test, production]
     services:
       postgres:
         image: postgres:16
@@ -66,7 +79,10 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Run tests
         env:
-          APP_ENV: test
+          APP_ENV: ${{ matrix.app_env }}
+          # Blanked so the production leg cannot fall back to the hardcoded DSN in
+          # settings.py and report CI runs as production traffic.
+          SENTRY_DSN: ''
           DB_NAME: owdb_test
           DB_USER: owdb
           DB_PASSWORD: testpassword

--- a/owdb_django/owdbapp/tests/test_production_settings.py
+++ b/owdb_django/owdbapp/tests/test_production_settings.py
@@ -1,0 +1,115 @@
+"""What settings.py hands production, checked from a suite that does not run it.
+
+`DEBUG = APP_ENV != "production"` gates a whole block of security settings, and
+the suite runs with `APP_ENV=test` (.github/workflows/ci.yml), so that block is
+skipped everywhere it is normally checked. Nothing gated it: the production
+config could lose HSTS, the secure-cookie flags or the /health/ redirect
+exemption and every test would stay green (ROS-1214).
+
+The behavioural half of this lives in test_security.py, which pins the
+production *values* under `override_settings` so the assertions survive any
+APP_ENV. This file pins the other half — that settings.py actually chooses those
+values when APP_ENV=production.
+
+It has to import settings a second time to do that, and settings.py is not
+re-importable in place: it calls `sentry_sdk.init()` at module scope, which would
+replace the running process's Sentry client. So each check runs in a subprocess
+with a clean environment, and with SENTRY_DSN blanked so the child cannot pick up
+the hardcoded production DSN and register itself as a live prod client.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+from django.conf import settings as ambient_settings
+from django.test import SimpleTestCase
+
+# Everything settings.py's `if not DEBUG` block is responsible for, plus the two
+# proxy settings it depends on. SECURE_PROXY_SSL_HEADER is outside the block but
+# belongs here: without it every proxied request looks insecure, SECURE_SSL_REDIRECT
+# 301s it, and production redirect-loops.
+EXPECTED_PRODUCTION_SETTINGS = {
+    "DEBUG": False,
+    "SECURE_BROWSER_XSS_FILTER": True,
+    "SECURE_CONTENT_TYPE_NOSNIFF": True,
+    "X_FRAME_OPTIONS": "DENY",
+    "SECURE_HSTS_SECONDS": 31536000,
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS": True,
+    "SECURE_HSTS_PRELOAD": True,
+    "SESSION_COOKIE_SECURE": True,
+    "CSRF_COOKIE_SECURE": True,
+    "SESSION_COOKIE_HTTPONLY": True,
+    "CSRF_COOKIE_HTTPONLY": True,
+    "SESSION_COOKIE_SAMESITE": "Lax",
+    "CSRF_COOKIE_SAMESITE": "Lax",
+    "SECURE_SSL_REDIRECT": True,
+    # json turns the tuple into a list on the way back.
+    "SECURE_PROXY_SSL_HEADER": ["HTTP_X_FORWARDED_PROTO", "https"],
+    "SECURE_REDIRECT_EXEMPT": ["^health/$", "^health/ready/$"],
+}
+
+_PROBE = (
+    "import json, sys\n"
+    "from django.conf import settings\n"
+    "print(json.dumps({n: getattr(settings, n, None) for n in json.loads(sys.argv[1])}, default=str))\n"
+)
+
+
+def settings_under_app_env(app_env, names):
+    """Import settings.py in a subprocess with APP_ENV=app_env; return the values."""
+    env = {
+        **os.environ,
+        "APP_ENV": app_env,
+        "DJANGO_SETTINGS_MODULE": "owdb_django.settings",
+        # A blank DSN makes sentry_sdk.init() a no-op. Without it the child would
+        # fall back to the hardcoded production DSN in settings.py.
+        "SENTRY_DSN": "",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE, json.dumps(list(names))],
+        cwd=ambient_settings.BASE_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"importing settings with APP_ENV={app_env!r} failed "
+            f"(exit {result.returncode}):\n{result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+class ProductionSecuritySettingsTest(SimpleTestCase):
+    """APP_ENV=production still turns on everything it is supposed to."""
+
+    # The failure message is the whole point of this test — show the full diff
+    # rather than unittest's truncated "[366 chars]".
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.production = settings_under_app_env("production", EXPECTED_PRODUCTION_SETTINGS.keys())
+
+    def test_production_security_settings(self):
+        """Assert the whole block at once so a removal shows up as a diff, not a hunt."""
+        self.assertEqual(self.production, EXPECTED_PRODUCTION_SETTINGS)
+
+
+class NonProductionAppEnvTest(SimpleTestCase):
+    """Why the test above needs a subprocess at all.
+
+    The suite's own APP_ENV is not production, so the security block does not run
+    in this process and reading `django.conf.settings` here would prove nothing.
+    Pinning that keeps the gap visible: if CI is ever pointed at APP_ENV=production
+    this test fails loudly rather than the coverage question going quiet again.
+    """
+
+    def test_test_env_does_not_enable_the_production_block(self):
+        values = settings_under_app_env("test", ["DEBUG", "SECURE_SSL_REDIRECT"])
+        self.assertTrue(values["DEBUG"])
+        self.assertFalse(values["SECURE_SSL_REDIRECT"])

--- a/owdb_django/owdbapp/tests/test_security.py
+++ b/owdb_django/owdbapp/tests/test_security.py
@@ -49,6 +49,37 @@ class SecurityHeadersTest(TestCase):
         response = self.client.get(reverse("index"))
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(
+        SECURE_HSTS_SECONDS=31536000,
+        SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
+        SECURE_HSTS_PRELOAD=True,
+    )
+    def test_hsts_header_on_proxied_https(self):
+        """The production HSTS settings produce the header we expect.
+
+        Values are overridden rather than read from settings so this carries the
+        same signal under APP_ENV=test, where the production block never runs
+        (ROS-1214). That the block *sets* these values is gated separately, in
+        test_production_settings.py.
+        """
+        response = self.client.get(reverse("index"))
+        self.assertEqual(
+            response.get("Strict-Transport-Security"),
+            "max-age=31536000; includeSubDomains; preload",
+        )
+
+    @override_settings(SECURE_HSTS_SECONDS=31536000)
+    def test_hsts_header_not_sent_over_plain_http(self):
+        """HSTS rides only on responses Django considers secure.
+
+        Not a nice-to-have: it is why the header depends on SECURE_PROXY_SSL_HEADER
+        and X-Forwarded-Proto surviving the proxy. A bare client stands in for a
+        request that lost them — if this ever starts returning the header, the
+        secure/insecure distinction has broken somewhere.
+        """
+        response = Client().get(reverse("index"))
+        self.assertIsNone(response.get("Strict-Transport-Security"))
+
 
 class CSRFProtectionTest(TestCase):
     """Tests for CSRF protection."""
@@ -181,6 +212,51 @@ class SessionSecurityTest(TestCase):
         self.client.post(reverse("logout"))
         # Session cookie should be cleared
         self.assertEqual(self.client.cookies["sessionid"].value, "")
+
+
+class ProductionCookieFlagsTest(TestCase):
+    """The session and CSRF cookies carry the flags production configures.
+
+    Same reasoning as the HSTS tests above: the values are overridden rather than
+    inherited from the ambient APP_ENV, so these keep their meaning under
+    APP_ENV=test where the production block is skipped entirely (ROS-1214).
+
+    Cookies are read off a real response, not off `client.login()` — the test
+    client's login shortcut copies `SESSION_COOKIE_SECURE` by hand and ignores
+    HttpOnly and SameSite, so it would pass even if SessionMiddleware set neither.
+    """
+
+    def setUp(self):
+        self.client = proxied_client()
+        self.user = User.objects.create_user(
+            username="cookieuser", email="cookie@example.com", password="testpassword123"
+        )
+
+    @override_settings(
+        SESSION_COOKIE_SECURE=True,
+        SESSION_COOKIE_HTTPONLY=True,
+        SESSION_COOKIE_SAMESITE="Lax",
+    )
+    def test_session_cookie_carries_production_flags(self):
+        response = self.client.post(
+            reverse("login"), {"username": "cookieuser", "password": "testpassword123"}
+        )
+        cookie = response.cookies["sessionid"]
+        self.assertTrue(cookie["secure"])
+        self.assertTrue(cookie["httponly"])
+        self.assertEqual(cookie["samesite"], "Lax")
+
+    @override_settings(
+        CSRF_COOKIE_SECURE=True,
+        CSRF_COOKIE_HTTPONLY=True,
+        CSRF_COOKIE_SAMESITE="Lax",
+    )
+    def test_csrf_cookie_carries_production_flags(self):
+        response = self.client.get(reverse("login"))
+        cookie = response.cookies["csrftoken"]
+        self.assertTrue(cookie["secure"])
+        self.assertTrue(cookie["httponly"])
+        self.assertEqual(cookie["samesite"], "Lax")
 
 
 class HealthCheckRedirectExemptTest(TestCase):


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` runs the suite with `APP_ENV: test`. `settings.py` does `DEBUG = APP_ENV != "production"` and puts every production security setting behind `if not DEBUG`. So the suite has never executed HSTS, the secure-cookie flags, `SECURE_SSL_REDIRECT`, or the `/health/` redirect exemptions as production actually sets them.

That is why ROS-1210's 34 red tests went unnoticed — not the Actions billing outage. A fully working CI would have missed all 34. ROS-1210 made the suite pass under both envs, but nothing *gated* the production config, so the next drift would have been silent too.

## Change

Both halves work today, under any `APP_ENV`:

- **`test_security.py`** — HSTS header and session/CSRF cookie-flag tests that pin the production values via `override_settings`, following the `test_proxied_https_is_not_redirected` pattern from ROS-1210. Covers the middleware behaviour. Cookies are read off a real response, not `client.login()` — the login shortcut copies `SESSION_COOKIE_SECURE` by hand and ignores HttpOnly/SameSite, so it would pass even if SessionMiddleware set neither.
- **`test_production_settings.py`** (new) — asserts settings.py actually *chooses* those values when `APP_ENV=production`, which no `override_settings` test can. It re-imports settings in a subprocess: settings.py calls `sentry_sdk.init()` at module scope, so re-importing in place would replace the running process's Sentry client. `SENTRY_DSN` is blanked in the child so it cannot fall back to the hardcoded production DSN and register as a live prod client.
- **`ci.yml`** — `APP_ENV: [test, production]` matrix with `fail-fast: false`. The direct fix, but inert while Actions is billing-disabled; the in-suite gate is what carries signal today. `SENTRY_DSN: ''` added for the same reason as above.

## Verification

Run in the `wrestlingdb-web` production image on the NUC, throwaway containers on a copy of this tree (`--network none`), prod tree untouched:

| | result |
|---|---|
| full suite, `APP_ENV=test` | 201 tests, **OK** |
| full suite, `APP_ENV=production` | 201 tests, **OK** |
| `ruff format --check` / `ruff check` | clean (199 files) |

Mutation-checked, all under `APP_ENV=test` — the config CI runs, where all of this was previously invisible:

| mutation | caught by |
|---|---|
| delete `SECURE_HSTS_SECONDS`, flip `SESSION_COOKIE_SECURE` to False | `test_production_security_settings` ✗ |
| `SECURE_PROXY_SSL_HEADER = None` (the redirect-loop regression) | `test_production_security_settings` ✗ |
| remove `SecurityMiddleware` | 3 behaviour tests ✗ |

No runtime code changed — tests and CI config only, so nothing to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)